### PR TITLE
Fix for Error "message.recipients.to must be of type Array."

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,11 @@ module.exports = {
             html: options.html || '',
           },
           recipients: {
-            to: options.to,
+            to: [
+              {
+                address: options.to
+              }
+            ],
             cc: options.cc,
             bcc: options.bcc,
           },


### PR DESCRIPTION
Fixes error on sending emails. Azure expects an Array.